### PR TITLE
docs: add intent-focused Korean comments

### DIFF
--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -1,5 +1,6 @@
-import type { AudioState } from './types';
+﻿import type { AudioState } from './types';
 
+// 오디오 매니저의 초기 상태. 소스를 비우고 안전한 기본값으로 시작
 export const DEFAULT_AUDIO_STATE: AudioState = {
   src: null,
   isPlaying: false,
@@ -10,4 +11,5 @@ export const DEFAULT_AUDIO_STATE: AudioState = {
   isReady: false,
 };
 
+// 진행률 저장 쓰기 간격(ms). 너무 자주 저장하지 않도록 기본 throttling 값 지정
 export const DEFAULT_THROTTLE_MS = 2000;

--- a/src/core/manager.ts
+++ b/src/core/manager.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_AUDIO_STATE, DEFAULT_THROTTLE_MS } from './constants';
+﻿import { DEFAULT_AUDIO_STATE, DEFAULT_THROTTLE_MS } from './constants';
 import { buildProgressKey, getStorage, loadProgressValue, saveProgressValue } from './storage';
 import type {
   AudioControls,
@@ -8,23 +8,30 @@ import type {
   UseGlobalAudioOptions,
 } from './types';
 
+// 모듈 스코프 싱글톤 상태
+// 오디오 엘리먼트와 스토어를 모듈 레벨에 1개로 유지하면
+// 라우트 전환에도 끊기지 않고, 훅을 어디서 쓰든 동일 상태를 공유
 let audio: HTMLAudioElement | null = null;
 let state: AudioState = { ...DEFAULT_AUDIO_STATE };
 const listeners = new Set<(next: AudioState) => void>();
 const eventHandlers = new Set<AudioEventHandlers>();
 
+// 런타임 설정(`configure`로 덮어씀)
 let rememberProgress = true;
 let storageMode: StorageMode = 'localStorage';
 let throttleMs = DEFAULT_THROTTLE_MS;
 let keyBuilder: ((src: string) => string) | undefined;
 
+// 진행률 저장 관련 상태
 let lastSavedAt = 0;
+// 메타데이터가 준비되기 전에 seek가 오면 보류했다가 준비되면 적용하기 위한 변수
 let pendingSeekTime: number | null = null;
 
 const notify = () => {
   listeners.forEach((listener) => listener(state));
 };
 
+// 등록된 이벤트 핸들러들에게 이벤트를 팬아웃(부수효과/분석 용도)
 const emitEvent = <K extends keyof AudioEventHandlers>(
   key: K,
   ...args: NonNullable<AudioEventHandlers[K]> extends (...params: infer P) => void ? P : []
@@ -38,11 +45,13 @@ const emitEvent = <K extends keyof AudioEventHandlers>(
   });
 };
 
+// 상태 업데이트 단일 경로. 모든 구독자가 항상 동기화 되도록 보장
 const setState = (partial: Partial<AudioState>) => {
   state = { ...state, ...partial };
   notify();
 };
 
+// currentTime을 쓰기 폭주 없이 저장하기 위해 throttling을 적용
 const saveProgress = (force = false) => {
   if (!rememberProgress || !state.src) return;
   const storage = getStorage(storageMode);
@@ -55,6 +64,7 @@ const saveProgress = (force = false) => {
   saveProgressValue(storage, buildProgressKey(keyBuilder, state.src), state.currentTime);
 };
 
+// 특정 소스에 대해 저장된 진행률을 불러옴
 const loadProgress = (src: string) => {
   if (!rememberProgress) return null;
   const storage = getStorage(storageMode);
@@ -62,6 +72,7 @@ const loadProgress = (src: string) => {
   return loadProgressValue(storage, buildProgressKey(keyBuilder, src));
 };
 
+// 단일 HTMLAudioElement를 지연 생성하고, DOM 이벤트를 스토어 업데이트로 연결
 const ensureAudio = () => {
   if (audio) return audio;
 
@@ -77,6 +88,7 @@ const ensureAudio = () => {
     if (!audio) return;
     setState({ duration: audio.duration || 0, isReady: true });
     emitEvent('onLoadedMetadata', audio.duration || 0);
+    // duration/메타데이터가 준비되면 보류된 seek를 적용한다.
     if (pendingSeekTime !== null) {
       audio.currentTime = Math.max(0, pendingSeekTime);
       setState({ currentTime: audio.currentTime });
@@ -119,6 +131,8 @@ const ensureAudio = () => {
 
 const getAudio = () => ensureAudio();
 
+// 활성 소스를 설정하거나 해제
+// src 변경을 중앙화해 여러 컴포넌트가 엘리먼트를 서로 덮어쓰지 않게 함
 const setSource = (src: string | null) => {
   const instance = ensureAudio();
 
@@ -131,6 +145,7 @@ const setSource = (src: string | null) => {
     return;
   }
 
+  // src가 실제로 바뀐 경우에만 다시 로드
   if (state.src !== src) {
     instance.pause();
     instance.src = src;
@@ -153,6 +168,7 @@ const setPendingSeek = (time: number | null) => {
   pendingSeekTime = time;
 };
 
+// 현재 소스를 재생하거나, 먼저 새 소스로 교체한 뒤 재생
 const play = async (src?: string) => {
   const instance = ensureAudio();
   if (src) {
@@ -161,7 +177,7 @@ const play = async (src?: string) => {
   try {
     await instance.play();
   } catch {
-    // autoplay or decode errors are handled by the browser
+    // 자동재생/디코드 오류는 브라우저가 처리
   }
 };
 
@@ -178,6 +194,7 @@ const stop = () => {
   saveProgress(true);
 };
 
+// 메타데이터가 준비되기 전에도 안전하게 seek하기 위해 지연 적용 지원
 const seek = (time: number) => {
   const instance = ensureAudio();
   const nextTime = Math.max(0, Math.min(state.duration || time, time));
@@ -203,6 +220,7 @@ const setPlaybackRate = (rate: number) => {
   setState({ rate: next });
 };
 
+// `useSyncExternalStore`에서 사용하는 외부 스토어 구독 API
 const subscribe = (listener: (next: AudioState) => void) => {
   listeners.add(listener);
   return () => {
@@ -212,6 +230,7 @@ const subscribe = (listener: (next: AudioState) => void) => {
 
 const getSnapshot = () => state;
 
+// 진행률 저장 동작을 설정. React 밖에서도 전역으로 공유
 const configure = (options: UseGlobalAudioOptions) => {
   rememberProgress = options.rememberProgress ?? true;
   storageMode = options.storage ?? 'localStorage';
@@ -219,6 +238,7 @@ const configure = (options: UseGlobalAudioOptions) => {
   keyBuilder = options.keyBuilder;
 };
 
+// 컨트롤은 안정적인 참조를 제공해 컴포넌트 메모이제이션에 유리
 const getControls = (): AudioControls => ({
   play,
   pause,

--- a/src/core/storage.ts
+++ b/src/core/storage.ts
@@ -1,23 +1,27 @@
-import type { StorageMode } from './types';
+﻿import type { StorageMode } from './types';
 
+// 선택한 저장소 백엔드를 반환하고, 비활성화면 null을 반환
 export const getStorage = (mode: StorageMode) => {
   if (mode === 'localStorage') return localStorage;
   if (mode === 'sessionStorage') return sessionStorage;
   return null;
 };
 
+// 나중에 진행률을 복원할 수 있도록 소스별 안정적인 키 생성
 export const buildProgressKey = (keyBuilder: ((src: string) => string) | undefined, src: string) =>
   keyBuilder ? keyBuilder(src) : `audio:progress:${src}`;
 
+// 프라이빗 모드/쿼터 등으로 storage가 throw할 수 있어 방어적으로 기록
 export const saveProgressValue = (storage: Storage | null, key: string, value: number) => {
   if (!storage) return;
   try {
     storage.setItem(key, String(Math.floor(value)));
   } catch {
-    // ignore storage errors
+    // 저장 실패가 재생 자체를 깨지 않도록 무시
   }
 };
 
+// 방어적으로 읽고, 파싱된 값이 유효한 숫자인지 검증
 export const loadProgressValue = (storage: Storage | null, key: string) => {
   if (!storage) return null;
   try {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,5 +1,7 @@
+﻿// 진행률 저장에 사용할 스토리지 선택지. false면 저장을 비활성화
 export type StorageMode = 'localStorage' | 'sessionStorage' | false;
 
+// 오디오 매니저가 전역으로 유지하는 단일 상태 스냅샷
 export type AudioState = {
   src: string | null;
   isPlaying: boolean;
@@ -11,6 +13,8 @@ export type AudioState = {
   error?: string;
 };
 
+// 훅/매니저 동작을 제어하는 옵션
+// 호출부는 선언적으로 옵션만 넘기고, 실제 동작은 매니저가 책임
 export type UseGlobalAudioOptions = {
   src?: string | null;
   autoPlay?: boolean;
@@ -20,6 +24,8 @@ export type UseGlobalAudioOptions = {
   keyBuilder?: (src: string) => string;
 };
 
+// 오디오 엘리먼트 이벤트를 외부로 전달하기 위한 핸들러 모음
+// 분석/로깅/부수효과를 재생 로직과 분리
 export type AudioEventHandlers = {
   onPlay?: () => void;
   onPause?: () => void;
@@ -31,6 +37,8 @@ export type AudioEventHandlers = {
   onError?: (error: string) => void;
 };
 
+// UI가 호출하는 재생 제어 API
+// 전역 매니저를 직접 만지지 않고, 안전한 표면만 노출
 export type AudioControls = {
   play: (src?: string) => Promise<void>;
   pause: () => void;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+﻿// 공개 API 표면: 전역 매니저, 타입, React 훅만 노출
 export * from './core/manager';
 export * from './core/types';
 export * from './react/useGlobalAudio';

--- a/src/react/useGlobalAudio.ts
+++ b/src/react/useGlobalAudio.ts
@@ -1,14 +1,21 @@
-import { useEffect, useMemo, useSyncExternalStore } from 'react';
+﻿import { useEffect, useMemo, useSyncExternalStore } from 'react';
 import { audioManager } from '../core/manager';
 import type { AudioControls, UseGlobalAudioOptions } from '../core/types';
 
+// 모듈 스코프 싱글톤 오디오 매니저를 React에서 쓰기 위한 훅.
+// - 외부 스토어 하나를 구독하면 라우트 전환에도 재생 유지
+// - 여러 곳에서 훅을 써도 항상 같은 상태 공유
 export const useGlobalAudio = (options: UseGlobalAudioOptions = {}) => {
   const { src, autoPlay = false } = options;
 
+  // 전역 매니저 설정을 최신 옵션과 동기화
+  // 런타임 동작에 영향을 주는 필드만 의존성에 포함
   useEffect(() => {
     audioManager.configure(options);
   }, [options.rememberProgress, options.storage, options.throttleMs, options.keyBuilder]);
 
+  // `src`가 제공/변경되면 싱글톤 소스를 갱신
+  // 자동재생 옵션도 여기서 처리해 호출부를 단순하게 유지
   useEffect(() => {
     if (src !== undefined) {
       audioManager.setSource(src);
@@ -18,12 +25,14 @@ export const useGlobalAudio = (options: UseGlobalAudioOptions = {}) => {
     }
   }, [src, autoPlay]);
 
+  // React 18에서 안전한 방식으로 외부 스토어를 구독
   const state = useSyncExternalStore(
     audioManager.subscribe,
     audioManager.getSnapshot,
     audioManager.getSnapshot
   );
 
+  // 컨트롤은 공유/안정 참조이므로 메모로 불필요한 렌더링 방지
   const controls = useMemo<AudioControls>(() => audioManager.getControls(), []);
 
   return { state, controls };


### PR DESCRIPTION
  ## Summary

  Add intent-focused Korean comments across the core global-audio modules to make the singleton + external-store design easier to
  understand and maintain.

  ## Related Issues

  - Closes #4

  ## Changes

  - Add “why/intent” comments to the singleton manager and external-store flow
  - Clarify hook behavior and option sync in useGlobalAudio
  - Document persistence safety and defensive storage handling
  - Add brief public API intent notes in types, constants, and index exports

  ## How To Test

  1. Run pnpm build
  2. Open any consumer app (or demo) and confirm existing playback behavior is unchanged

  ## Checklist

  - [x] Title follows the convention (e.g., feat: add global audio seek guard)
  - [ ] Build passes locally (pnpm build)
  - [x] No breaking changes, or they are documented below
  - [ ] Tests added/updated where appropriate
  - [x] Docs/comments updated where helpful

  ## Breaking Changes (if any)

  None.

  ## Notes For Reviewers

  This PR is documentation-only (comments). There should be no runtime behavior changes.

  ## Screenshots / Recordings (if UI changes)

  N/A.